### PR TITLE
Handle DB connection errors in index page

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,6 +1,13 @@
 <?php
     include('mysqli_connect.php');
-    include('db_queries.php');
+
+    $error_message = null;
+    if ($db_error !== null) {
+        $error_message = $db_error;
+        $telemoveis = [];
+    } else {
+        include('db_queries.php');
+    }
 ?>
 
 <!DOCTYPE html>
@@ -15,6 +22,12 @@
 <body>
 <div class="container mt-5">
     <h1 class="text-center mb-4">Catálogo de Telemóveis</h1>
+
+    <?php if ($error_message): ?>
+        <div class="alert alert-danger" role="alert">
+            Erro na ligação à base de dados: <?= htmlspecialchars($error_message) ?>
+        </div>
+    <?php endif; ?>
 
     <!-- Botão Adicionar -->
     <button class="btn btn-success mb-3" data-toggle="modal" data-target="#addModal">Adicionar Telemóvel</button>

--- a/mysqli_connect.php
+++ b/mysqli_connect.php
@@ -1,8 +1,10 @@
 <?php
+$db_error = null;
 try {
     $pdo = new PDO("mysql:host=localhost;dbname=telemoveis_bd", "root", "1234");
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 } catch (PDOException $e) {
-    die("Erro na ligação: " . $e->getMessage());
+    $db_error = $e->getMessage();
+    $pdo = null;
 }
 ?>


### PR DESCRIPTION
## Summary
- handle DB errors in `mysqli_connect.php` without terminating the script
- show the error message on `index.php` while still rendering the page

## Testing
- `php -l index.php` *(fails: `php` not installed)*
- `terraform -version` *(fails: `terraform` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b4c190a688326bff5ddfcba23a254