### PR TITLE
Add subscription id variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Este repositório contém a infraestrutura e o código da aplicação **Catálog
    ```bash
    terraform apply -var="subscription_id=<o-seu-id>" -auto-approve
    ```
+Substitua `<o-seu-id>` pelo ID da sua subscrição Azure.
 
 Após a conclusão, o Terraform irá apresentar o endereço IP público da máquina virtual Web. Utilize esse endereço no seu browser para aceder à aplicação.
 

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,11 @@ provider "azurerm" {
   subscription_id = var.subscription_id
 }
 
+variable "subscription_id" {
+  type        = string
+  description = "Azure subscription ID"
+}
+
 variable "location" {
   default = "South Africa North"
 }


### PR DESCRIPTION
## Summary
- add variable `subscription_id` for Azure subscription
- mention the variable in the usage instructions

## Testing
- `terraform fmt main.tf` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b78037cb88326923301a45c09aa01